### PR TITLE
Rename scoreboard team removal helper

### DIFF
--- a/src/main/java/com/auroraschaos/minigames/party/PartyManager.java
+++ b/src/main/java/com/auroraschaos/minigames/party/PartyManager.java
@@ -93,8 +93,8 @@ public class PartyManager {
             playerToParty.remove(memberUUID);
             Player p = Bukkit.getPlayer(memberUUID);
             if (p != null && p.isOnline()) {
-                // Reset name color to default (by removing them from the team)
-                ScoreboardTeamRemover(p);
+                // Reset name color to default (by removing them from any teams)
+                removeFromScoreboardTeams(p);
             }
         }
 
@@ -225,10 +225,10 @@ public class PartyManager {
      * If you need to forcibly remove a player’s name from any scoreboard team (e.g. when they leave),
      * call this method.
      */
-    private void ScoreboardTeamRemover(Player p) {
+    private void removeFromScoreboardTeams(Player player) {
         for (Team team : mainScoreboard.getTeams()) {
-            if (team.hasEntry(p.getName())) {
-                team.removeEntry(p.getName());
+            if (team.hasEntry(player.getName())) {
+                team.removeEntry(player.getName());
             }
         }
     }


### PR DESCRIPTION
## Summary
- rename `ScoreboardTeamRemover` to `removeFromScoreboardTeams`
- update call site in `PartyManager`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852c3a901608330a999a37b1f37e047